### PR TITLE
Upgrade HARK from 0.14.1 to 0.17.0

### DIFF
--- a/Code/HA-Models/FromPandemicCode/AggFiscalModel.py
+++ b/Code/HA-Models/FromPandemicCode/AggFiscalModel.py
@@ -4,10 +4,10 @@ This file has an extension of MarkovConsumerType that is used for the Fiscal pro
 import warnings
 import numpy as np
 import scipy.sparse as sp
-from HARK.distribution import DiscreteDistribution, Uniform
+from HARK.distributions import DiscreteDistribution, Uniform
 from HARK.ConsumptionSaving.ConsMarkovModel import MarkovConsumerType
 from HARK.ConsumptionSaving.ConsIndShockModel import ConsumerSolution
-from HARK.ConsumptionSaving.ConsAggShockModel import MargValueFunc2D, AggShockConsumerType
+from HARK.ConsumptionSaving.ConsAggShockModel import MargValueFuncCRRA as MargValueFunc2D, AggShockConsumerType
 from HARK.interpolation import LinearInterp, BilinearInterp, VariableLowerBoundFunc2D, \
                                 LinearInterpOnInterp1D, LowerEnvelope2D, UpperEnvelope, ConstantFunction
 from HARK import Market
@@ -36,7 +36,7 @@ class AggFiscalType(MarkovConsumerType):
         self.add_to_time_vary('IncShkDstn','PermShkDstn','TranShkDstn')
         self.add_to_time_inv('aXtraGrid', 'Rfree')
         
-    def updateSolutionTerminal(self):
+    def update_solution_terminal(self):
         AggShockConsumerType.update_solution_terminal(self)
         # Make replicated terminal period solution
         StateCount = self.MrkvArray[-1].shape[0]
@@ -47,7 +47,7 @@ class AggFiscalType(MarkovConsumerType):
     def pre_solve(self):
         self.MrkvArray = self.MrkvArray
         MarkovConsumerType.pre_solve(self)
-        self.updateSolutionTerminal()
+        self.update_solution_terminal()
         
     def initialize_sim(self):
         MarkovConsumerType.initialize_sim(self)
@@ -104,7 +104,7 @@ class AggFiscalType(MarkovConsumerType):
         self.ADFunc = Economy.ADFunc                 # Function that takes aggregate consumption to agg. demand function
         self.add_to_time_inv('Cgrid', 'CFunc','ADFunc','num_experiment_periods','num_base_MrkvStates')
         # self.PermGroFacAgg = Economy.PermGroFacAgg   # Aggregate permanent productivity growth
-        #self.addToTimeInv('Cgrid', 'CFunc', 'PermGroFacAgg','ADFunc')
+        #self.add_to_time_inv('Cgrid', 'CFunc', 'PermGroFacAgg','ADFunc')
         
     def save_state(self):
         '''

--- a/Code/HA-Models/FromPandemicCode/ConsMarkovModel.py
+++ b/Code/HA-Models/FromPandemicCode/ConsMarkovModel.py
@@ -16,7 +16,7 @@ from HARK.ConsumptionSaving.ConsIndShockModel import (
     IndShockConsumerType,
     PerfForesightConsumerType,
 )
-from HARK.distribution import MarkovProcess, Uniform, calc_expectation
+from HARK.distributions import MarkovProcess, Uniform, calc_expectation
 from HARK.interpolation import (
     CubicInterp,
     LinearInterp,

--- a/Code/HA-Models/FromPandemicCode/EstimAggFiscalMAIN.py
+++ b/Code/HA-Models/FromPandemicCode/EstimAggFiscalMAIN.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from collections import namedtuple 
 import pickle
 import random 
-from HARK.distribution import DiscreteDistribution, Uniform
+from HARK.distributions import DiscreteDistribution, Uniform
 from HARK import multi_thread_commands, multi_thread_commands_fake
 from HARK.utilities import get_percentiles, get_lorenz_shares
 from HARK.estimation import minimize_nelder_mead
@@ -485,7 +485,7 @@ def calcMPCbyWealthQ(Agents,lotterySize):
                 P_hist[:,period] = ThisType.shocks["PermShk"]
                 for i_agent in range(ThisType.AgentCount):
                     if ThisType.shocks["TranShk"][i_agent] == 1.0: # indicator of death
-                        a_actu[i_agent,period-1,k] = np.exp(np.log(0.00001)) #base_params['aNrmInitMean']
+                        a_actu[i_agent,period-1,k] = np.exp(np.log(0.00001)) #base_params['kLogInitMean']
                 m_adj = a_actu[:,period-1,k]*R_kink/ThisType.shocks["PermShk"] + ThisType.shocks["TranShk"] + Lnrm - SplurgeNrm #continue with resources from last period
                 for aa in range(0,ThisType.AgentCount):
                     c_actu[aa,period,k] = ThisType.cFunc[0][ThisType.MicroMrkvNow[aa]](m_adj[aa],1) + SplurgeNrm[aa]
@@ -668,7 +668,7 @@ IncomeDstn_unemp_nobenefits = DiscreteDistribution(np.array([1.0]), [np.array([1
 for ThisType in BaseTypeList:
     EmployedIncomeDstn = deepcopy(ThisType.IncShkDstn[0])
     ThisType.IncShkDstn = [[ThisType.IncShkDstn[0]] + [IncomeDstn_unemp]*UBspell_normal + [IncomeDstn_unemp_nobenefits]]
-    ThisType.IncomeDstn_base = ThisType.IncShkDstn
+    ThisType.IncShkDstn_base = ThisType.IncShkDstn
     
 # Make the overall list of types
 TypeList = []
@@ -792,8 +792,8 @@ def betasObjFunc(betas, spreads, GICfactors, target_option=1, print_mode=False, 
     AggDemandEconomy.save_state()   
 
     # Simulate each type to get a new steady state solution 
-    # solve: done in AggDemandEconomy.solve(), initializeSim: done in AggDemandEconomy.reset() 
-    # baseline_commands = ['solve()', 'initializeSim()', 'simulate()', 'saveState()']
+    # solve: done in AggDemandEconomy.solve(), initialize_sim: done in AggDemandEconomy.reset() 
+    # baseline_commands = ['solve()', 'initialize_sim()', 'simulate()', 'save_state()']
     # baseline_commands = ['simulate()', 'save_state()']
     baseline_commands = ['solve()', 'initialize_sim()', 'simulate()', 'save_state()', 'unpack_cFunc()']
     multi_thread_commands_fake(TypeListNew, baseline_commands)
@@ -975,8 +975,8 @@ def betasObjFuncEduc(beta, spread, GICx, educ_type=2, print_mode=False, print_fi
     AggDemandEconomy.save_state()   
 
     # Simulate each type to get a new steady state solution 
-    # solve: done in AggDemandEconomy.solve(), initializeSim: done in AggDemandEconomy.reset() 
-    # baseline_commands = ['solve()', 'initializeSim()', 'simulate()', 'saveState()']
+    # solve: done in AggDemandEconomy.solve(), initialize_sim: done in AggDemandEconomy.reset() 
+    # baseline_commands = ['solve()', 'initialize_sim()', 'simulate()', 'save_state()']
     # baseline_commands = ['simulate()', 'save_state()']
     baseline_commands = ['solve()', 'initialize_sim()', 'simulate()', 'save_state()']
     multi_thread_commands_fake(TypeListAll, baseline_commands)

--- a/Code/HA-Models/FromPandemicCode/EstimAggFiscalModel.py
+++ b/Code/HA-Models/FromPandemicCode/EstimAggFiscalModel.py
@@ -3,10 +3,10 @@ This file has an extension of MarkovConsumerType that is used for the Fiscal pro
 '''
 import warnings
 import numpy as np
-from HARK.distribution import DiscreteDistribution, Uniform
+from HARK.distributions import DiscreteDistribution, Uniform
 from HARK.ConsumptionSaving.ConsMarkovModel import MarkovConsumerType
 from HARK.ConsumptionSaving.ConsIndShockModel import ConsumerSolution
-from HARK.ConsumptionSaving.ConsAggShockModel import MargValueFunc2D, AggShockConsumerType
+from HARK.ConsumptionSaving.ConsAggShockModel import MargValueFuncCRRA as MargValueFunc2D, AggShockConsumerType
 from HARK.interpolation import LinearInterp, BilinearInterp, VariableLowerBoundFunc2D, \
                                 LinearInterpOnInterp1D, LowerEnvelope2D, UpperEnvelope, ConstantFunction
 from HARK import Market
@@ -23,37 +23,41 @@ class AggFiscalType(MarkovConsumerType):
     def __init__(self,cycles=1,time_flow=True,**kwds):
         MarkovConsumerType.__init__(self,cycles=1,time_flow=True,**kwds)
         self.shock_vars += ['update_draw','unemployment_draw']
-        self.solveOnePeriod = solveAggConsMarkovALT
+        self.solve_one_period = solveAggConsMarkovALT
         # Add consumer-type specific objects, copying to create independent versions
         self.time_vary = deepcopy(MarkovConsumerType.time_vary_)
         self.time_inv = deepcopy(MarkovConsumerType.time_inv_)
-        self.delFromTimeInv('vFuncBool', 'CubicBool')
-        self.addToTimeVary('IncomeDstn','PermShkDstn','TranShkDstn')
-        self.addToTimeInv('aXtraGrid')
+        self.del_from_time_inv('vFuncBool', 'CubicBool')
+        self.add_to_time_vary('IncShkDstn','PermShkDstn','TranShkDstn')
+        self.add_to_time_inv('aXtraGrid')
         
-    def updateSolutionTerminal(self):
-        AggShockConsumerType.updateSolutionTerminal(self)
+    def update_solution_terminal(self):
+        AggShockConsumerType.update_solution_terminal(self)
         # Make replicated terminal period solution
         StateCount = self.MrkvArray[-1].shape[0]
         self.solution_terminal.cFunc = StateCount*[self.solution_terminal.cFunc]
         self.solution_terminal.vPfunc = StateCount*[self.solution_terminal.vPfunc]
         self.solution_terminal.mNrmMin = StateCount*[self.solution_terminal.mNrmMin]
         
-    def preSolve(self):
+    def pre_solve(self):
         self.MrkvArray = self.MrkvArray
-        MarkovConsumerType.preSolve(self)
-        self.updateSolutionTerminal()
+        MarkovConsumerType.pre_solve(self)
+        self.update_solution_terminal()
         
-    def initializeSim(self):
-        MarkovConsumerType.initializeSim(self)
+    def initialize_sim(self):
+        MarkovConsumerType.initialize_sim(self)
         if hasattr(self,'use_prestate'):
-            self.restoreState()
+            self.restore_state()
         else:   # set to ergodic unemployment rate during normal times
-            init_unemp_dist = DiscreteDistribution(1.0-self.Urate_normal, np.array([0,1]), seed=self.RNG.randint(0,2**31-1))
-            self.MrkvNow[:] = init_unemp_dist.drawDiscrete(self.AgentCount)
+            init_unemp_dist = DiscreteDistribution(
+            np.array([1.0-self.Urate_normal, self.Urate_normal]), # Array of TWO probabilities
+            np.array([0,1]), 
+            seed=self.RNG.integers(2**31-1)
+        )
+            self.MrkvNow[:] = init_unemp_dist.draw_events(self.AgentCount)
             if not hasattr(self,'mortality_off'):
-                self.calcAgeDistribution()
-                self.initializeAges()
+                self.calc_age_distribution()
+                self.initialize_ages()
         if (hasattr(self,'Mrkv_univ') and self.Mrkv_univ is not None):
             self.MrkvNow[:] = self.Mrkv_univ
         self.MacroMrkvNow = (np.floor(self.MrkvNow/self.num_base_MrkvStates)).astype(int)
@@ -61,7 +65,7 @@ class AggFiscalType(MarkovConsumerType):
         self.EconomyMrkvNow = self.MacroMrkvNow #For aggregate model only
         self.EconomyMrkvNow_hist = [0] * self.T_sim #For aggregate model only
         
-    def getMortality(self):
+    def get_mortality(self):
         '''
         A modified version of getMortality that reads mortality history if the
         attribute read_mortality exists.  This is a workaround to make sure the
@@ -70,17 +74,17 @@ class AggFiscalType(MarkovConsumerType):
         if (self.read_shocks or hasattr(self,'read_mortality')):
             who_dies = self.who_dies_fixed_hist[self.t_sim,:]
         else:
-            who_dies = self.simDeath()
-        self.simBirth(who_dies)
+            who_dies = self.sim_death()
+        self.sim_birth(who_dies)
         self.who_dies = who_dies
         return None
     
-    def simDeath(self):
+    def sim_death(self):
         if hasattr(self,'mortality_off'):
             return np.zeros(self.AgentCount, dtype=bool)
         else:
-            return MarkovConsumerType.simDeath(self)        
-    def getEconomyData(self, Economy):
+            return MarkovConsumerType.sim_death(self)        
+    def get_economy_data(self, Economy):
         '''
         Imports economy-determined objects into self from a Market.
         Parameters
@@ -95,11 +99,11 @@ class AggFiscalType(MarkovConsumerType):
         self.Cgrid = Economy.CgridBase               # Ratio of consumption to steady state consumption
         self.CFunc = Economy.CFunc                   # Next period's consumption ratio function
         self.ADFunc = Economy.ADFunc                 # Function that takes aggregate consumption to agg. demand function
-        self.addToTimeInv('Cgrid', 'CFunc','ADFunc','num_base_MrkvStates')
+        self.add_to_time_inv('Cgrid', 'CFunc','ADFunc','num_base_MrkvStates')
         # self.PermGroFacAgg = Economy.PermGroFacAgg   # Aggregate permanent productivity growth
-        #self.addToTimeInv('Cgrid', 'CFunc', 'PermGroFacAgg','ADFunc')
+        #self.add_to_time_inv('Cgrid', 'CFunc', 'PermGroFacAgg','ADFunc')
         
-    def saveState(self):
+    def save_state(self):
         '''
         Record the current state of simulation variables for later use.
         '''
@@ -111,7 +115,7 @@ class AggFiscalType(MarkovConsumerType):
         self.t_sim_base = self.t_sim
         self.PlvlAgg_base = self.PlvlAggNow
 
-    def restoreState(self):
+    def restore_state(self):
         '''
         Restore the state of the simulation to some baseline values.
         '''
@@ -125,7 +129,7 @@ class AggFiscalType(MarkovConsumerType):
     def makeIdiosyncraticShockHistories(self):     
         self.Mrkv_univ = 0
         self.read_shocks = False
-        self.makeShockHistory()
+        self.make_shock_history()
         self.who_dies_fixed_hist    = self.history['who_dies'].copy()
         self.update_draw_fixed_hist = self.history['update_draw'].copy()
         self.perm_shock_fixed_hist  = self.history['PermShkNow'].copy()
@@ -133,7 +137,7 @@ class AggFiscalType(MarkovConsumerType):
         self.unemployment_draw_fixed_hist = self.history['unemployment_draw'].copy()
         self.Mrkv_univ = None
         
-    def hitWithRecessionShock(self, shock_type):
+    def hit_with_recession_shock(self, shock_type):
         '''
         Alter the Markov state of each simulated agent, jumping some people into
         recession states
@@ -145,7 +149,7 @@ class AggFiscalType(MarkovConsumerType):
             this_Urate = self.Urate_normal
         
         # Draw new Markov states for each agents who are employed
-        draws = Uniform(seed=self.RNG.randint(0,2**31-1)).draw(self.AgentCount)
+        draws = Uniform(seed=self.RNG.integers(2**31-1)).draw(self.AgentCount)
         draws = self.RNG.permutation(draws)
         MrkvNew = self.MrkvNow
         old_Urate = self.Urate_normal
@@ -212,7 +216,7 @@ class AggFiscalType(MarkovConsumerType):
         
     def switchToCounterfactualMode(self, shock_type):
         del self.solution
-        self.delFromTimeVary('solution')
+        self.del_from_time_vary('solution')
         self.switch_shock_type(shock_type)
         # Adjust simulation parameters for the counterfactual experiments
         self.T_sim = T_sim
@@ -224,34 +228,34 @@ class AggFiscalType(MarkovConsumerType):
         # Swap in "big" versions of the Markov-state-varying attributes
         if shock_type == "base":
             self.MrkvArray = self.MrkvArray_base
-            self.IncomeDstn = self.IncomeDstn_base
+            self.IncomeDstn = self.IncShkDstn_base
 #            self.CondMrkvArrays = self.CondMrkvArrays_recession
         elif shock_type == "recession":
             self.MrkvArray = self.MrkvArray_recession
-            self.IncomeDstn = self.IncomeDstn_recession
+            self.IncomeDstn = self.IncShkDstn_recession
             self.CondMrkvArrays = self.CondMrkvArrays_recession
         elif shock_type == "recessionUI":
             self.MrkvArray = self.MrkvArray_recessionUI
-            self.IncomeDstn = self.IncomeDstn_recessionUI
+            self.IncomeDstn = self.IncShkDstn_recessionUI
             self.CondMrkvArrays = self.CondMrkvArrays_recessionUI
         elif shock_type == "recessionTaxCut":
             self.MrkvArray = self.MrkvArray_recessionTaxCut
-            self.IncomeDstn = self.IncomeDstn_recessionTaxCut
+            self.IncomeDstn = self.IncShkDstn_recessionTaxCut
             self.CondMrkvArrays = self.CondMrkvArrays_recessionTaxCut
         elif shock_type == "recessionCheck":
             self.MrkvArray = self.MrkvArray_recessionCheck
-            self.IncomeDstn = self.IncomeDstn_recessionCheck
+            self.IncomeDstn = self.IncShkDstn_recessionCheck
             self.CondMrkvArrays = self.CondMrkvArrays_recessionCheck
         num_mrkv_states = self.MrkvArray[0].shape[0]
         self.LivPrb = [np.array(self.LivPrb_base*num_mrkv_states)]
         self.PermGroFac =  [np.array(self.PermGroFac_base*num_mrkv_states)]
         self.Rfree = np.array(num_mrkv_states*self.Rfree_base)
         
-    def getRfree(self):
+    def get_Rfree(self):
         RfreeNow = self.Rfree[self.MrkvNow]*np.ones(self.AgentCount)
         return RfreeNow
     
-    def marketAction(self):
+    def market_action(self):
         self.simulate(1)
         
     def getCratioNow(self):  # This function exists to be overwritten in StickyE model
@@ -260,8 +264,8 @@ class AggFiscalType(MarkovConsumerType):
     def getAggDemandFacNow(self):  
         return self.AggDemandFac*np.ones(self.AgentCount)
 
-    def getShocks(self):
-        MarkovConsumerType.getShocks(self)
+    def get_shocks(self):
+        MarkovConsumerType.get_shocks(self)
         if (hasattr(self,'Mrkv_univ') and self.Mrkv_univ is not None):
             self.MrkvNow = self.MrkvNow_temp # Make sure real sequence is recorded
         self.update_draw = self.RNG.permutation(np.array(range(self.AgentCount))) # A list permuted integers, low draws will update their aggregate Markov state
@@ -269,8 +273,8 @@ class AggFiscalType(MarkovConsumerType):
             self.MrkvNow = self.MrkvNow_temp # Make sure real sequence is recorded
         self.update_draw = self.RNG.permutation(np.array(range(self.AgentCount))) # A list permuted integers, low draws will update their aggregate Markov state
                    
-    def getStates(self):
-        MarkovConsumerType.getStates(self)
+    def get_states(self):
+        MarkovConsumerType.get_states(self)
         
         # Initialize the random draw of Pi*N agents who update
         how_many_update = int(round(self.UpdatePrb*self.AgentCount))
@@ -312,7 +316,7 @@ class AggFiscalType(MarkovConsumerType):
         self.MicroMrkvNow = MicroMrkvNow.astype(int)
         
     def getMicroMarkovStates(self):
-        self.unemployment_draw = Uniform(seed=self.RNG.randint(0,2**31-1)).draw(self.AgentCount)
+        self.unemployment_draw = Uniform(seed=self.RNG.integers(2**31-1)).draw(self.AgentCount)
         self.getMicroMarkvStates_guts(self.unemployment_draw)
            
     def getMarkovStates(self):
@@ -325,7 +329,7 @@ class AggFiscalType(MarkovConsumerType):
             self.MrkvNow = self.Mrkv_univ*np.ones(self.AgentCount, dtype=int)
             # ^^ Store the real states but force income shocks to be based on one particular state
             
-    def updateMrkvArray(self, shock_type):
+    def update_mrkv_array(self, shock_type):
         if shock_type=="base":
             self.MacroMrkvArray = np.array([[1.0]])
             self.CondMrkvArrays = makeCondMrkvArrays_base(self.Urate_normal, self.Uspell_normal, self.UBspell_normal)
@@ -333,7 +337,7 @@ class AggFiscalType(MarkovConsumerType):
         else:
             print("shock_type not recognized")
     
-    def solveIfChanged(self):
+    def solve_if_changed(self):
         '''
         Re-solve the lifecycle model only if the attributes MrkvArray
         do not match those in MrkvArray_prev .
@@ -350,7 +354,7 @@ class AggFiscalType(MarkovConsumerType):
         self.solve()
         self.MrkvArray_prev = self.MrkvArray
     
-    def calcAgeDistribution(self):
+    def calc_age_distribution(self):
         '''
         Calculates the long run distribution of t_cycle in the population.
         '''
@@ -378,21 +382,21 @@ class AggFiscalType(MarkovConsumerType):
         LRagePrbs /= np.sum(LRagePrbs)
         age_vec = np.arange(T_cycle_actual+1).astype(int)
         self.LRageDstn = DiscreteDistribution(LRagePrbs, age_vec,
-                                seed=self.RNG.randint(0,2**31-1))
+                                seed=self.RNG.integers(2**31-1))
         
         
-    def initializeAges(self):
+    def initialize_ages(self):
         '''
         Assign initial values of t_cycle to simulated agents, using the attribute
         LRageDstn as the distribution of discrete ages.
         '''
-        age = self.LRageDstn.drawDiscrete(self.AgentCount)
+        age = self.LRageDstn.draw_events(self.AgentCount)
         age = age.astype(int)
         if self.T_cycle!=1:
             self.t_cycle = age
         self.t_age = age
                    
-    def getControls(self):
+    def get_controls(self):
         cNrmNow = np.zeros(self.AgentCount) + np.nan
         MPCnow = np.zeros(self.AgentCount) + np.nan
         CratioNow = self.getCratioNow()
@@ -632,7 +636,7 @@ class AggregateDemandEconomy(Market):
         self.update()
 
 
-    def millRule(self, cLvl_splurgeNow):
+    def mill_rule(self, cLvl_splurgeNow):
         if self.Shk_idx==0:
             EconomyMrkvNow = 0
         else:
@@ -658,7 +662,7 @@ class AggregateDemandEconomy(Market):
         self.Shk_idx += 1
         return mill_return
 
-    def calcDynamics(self):
+    def calc_dynamics(self):
         return self.calcCFunc()
 
     def update(self):
@@ -679,14 +683,14 @@ class AggregateDemandEconomy(Market):
             CFunc_all.append(copy(CFunc_i))
         self.CFunc = CFunc_all
         for agent in self.agents:
-            agent.getEconomyData(self)
+            agent.get_economy_data(self)
 
     def reset(self):
         self.Shk_idx = 0
         Market.reset(self)
         #self.EconomyMrkvNow_hist = [0] * self.act_T
         for agent in self.agents:
-            agent.initializeSim()
+            agent.initialize_sim()
         
     def runExperiment(self, shock_type = "recession", UpdatePrb = 1.0, Splurge = 0.0, EconomyMrkv_init = [0], Full_Output = True):
         # Make the macro markov history
@@ -709,13 +713,13 @@ class AggregateDemandEconomy(Market):
         for ThisType in self.agents:
             ThisType.read_shocks = True
             ThisType(**experiment_dict)
-            ThisType.updateMrkvArray(shock_type)
-            ThisType.solveIfChanged()
-            ThisType.initializeSim()
+            ThisType.update_mrkv_array(shock_type)
+            ThisType.solve_if_changed()
+            ThisType.initialize_sim()
             ThisType.EconomyMrkvNow_hist = self.EconomyMrkvNow_hist
-            ThisType.hitWithRecessionShock(shock_type)
+            ThisType.hit_with_recession_shock(shock_type)
             PopCount += ThisType.AgentCount
-        self.makeHistory()
+        self.make_history()
         
         
            
@@ -804,7 +808,7 @@ class AggregateDemandEconomy(Market):
         self.switch_shock_type(shock_type)
         self.act_T = T_sim
         for agent in self.agents:
-            agent.getEconomyData(self)
+            agent.get_economy_data(self)
             agent.switchToCounterfactualMode(shock_type)
             
     def switch_shock_type(self, shock_type):
@@ -824,11 +828,11 @@ class AggregateDemandEconomy(Market):
         self.calcCFunc()
         for agent in self.agents:
             agent.switch_shock_type(shock_type)
-            agent.getEconomyData(self)
+            agent.get_economy_data(self)
             
-    def saveState(self):
+    def save_state(self):
         for agent in self.agents:
-            agent.saveState()
+            agent.save_state()
             
     def storeBaseline(self, AggCons):
         self.base_AggCons = copy(AggCons)
@@ -848,7 +852,7 @@ class AggregateDemandEconomy(Market):
         self.ADelasticity = self.stored_solutions[name].ADelasticity
         for i in range(len(self.agents)):
             self.agents[i].solution = self.stored_solutions[name].agent_solutions[i]
-            self.agents[i].getEconomyData(self)
+            self.agents[i].get_economy_data(self)
         
     def makeIdiosyncraticShockHistories(self):
         for agent in self.agents:

--- a/Code/HA-Models/FromPandemicCode/EstimParameters.py
+++ b/Code/HA-Models/FromPandemicCode/EstimParameters.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 import sys
-from HARK.distribution import Uniform
+from HARK.distributions import Uniform
 
 # Targets in the estimation of the discount factor distributions for each 
 # education level. 
@@ -240,10 +240,10 @@ init_dropout = {"cycles": 0, # This will be overwritten at type construction
                 "aXtraNestFac": aXtraNestFac,
                 "CubicBool": False,
                 "vFuncBool": False,
-                'aNrmInitMean': np.log(0.00001), # Initial assets are zero
-                'aNrmInitStd': 0.0,
-                'pLvlInitMean': pLvlInitMean_d,
-                'pLvlInitStd': pLvlInitStd_d,
+                'kLogInitMean': np.log(0.00001), # Initial assets are zero
+                'kLogInitStd': 0.0,
+                'pLogInitMean': pLvlInitMean_d,
+                'pLogInitStd': pLvlInitStd_d,
                 "MrkvPrbsInit" : np.array(list(init_mrkv_dist_d)),
                 'Urate_normal' : Urate_normal_d,
                 'Uspell_normal' : Uspell_normal,
@@ -263,8 +263,8 @@ adj_highschool = {
     "CondMrkvArrays_base" : CondMrkvArrays_base_h,
     "MrkvArray" : MrkvArray_base_h, 
     "CondMrkvArrays" : CondMrkvArrays_base_h,
-    'pLvlInitMean': pLvlInitMean_h,
-    'pLvlInitStd': pLvlInitStd_h,
+    'pLogInitMean': pLvlInitMean_h,
+    'pLogInitStd': pLvlInitStd_h,
     "MrkvPrbsInit" : np.array(list(init_mrkv_dist_h)),
     'Urate_normal' : Urate_normal_h,
     'EducType' : 1}
@@ -278,8 +278,8 @@ adj_college = {
     "CondMrkvArrays_base" : CondMrkvArrays_base_c,
     "MrkvArray" : MrkvArray_base_c, 
     "CondMrkvArrays" : CondMrkvArrays_base_c,
-    'pLvlInitMean': pLvlInitMean_c,
-    'pLvlInitStd': pLvlInitStd_c,
+    'pLogInitMean': pLvlInitMean_c,
+    'pLogInitStd': pLvlInitStd_c,
     "MrkvPrbsInit" : np.array(list(init_mrkv_dist_c)),
     'Urate_normal' : Urate_normal_c,
     'EducType' : 2}

--- a/Code/HA-Models/FromPandemicCode/EstimSetupEconomy.py
+++ b/Code/HA-Models/FromPandemicCode/EstimSetupEconomy.py
@@ -2,7 +2,7 @@ from EstimParameters import T_sim, init_dropout, init_highschool, init_college, 
      AgentCountTotal, EducShares, base_dict, figs_dir, num_max_iterations_solvingAD,\
      convergence_tol_solvingAD, UBspell_normal, num_base_MrkvStates
 from EstimAggFiscalModel import AggFiscalType, AggregateDemandEconomy
-from HARK.distribution import DiscreteDistribution
+from HARK.distributions import DiscreteDistribution
 import numpy as np
 from copy import deepcopy
 
@@ -16,9 +16,9 @@ InfHorizonTypeAgg_d = AggFiscalType(**init_dropout)
 InfHorizonTypeAgg_h = AggFiscalType(**init_highschool)
 InfHorizonTypeAgg_c = AggFiscalType(**init_college)
 AggDemandEconomy = AggregateDemandEconomy(**init_ADEconomy)
-InfHorizonTypeAgg_d.getEconomyData(AggDemandEconomy)
-InfHorizonTypeAgg_h.getEconomyData(AggDemandEconomy)
-InfHorizonTypeAgg_c.getEconomyData(AggDemandEconomy)
+InfHorizonTypeAgg_d.get_economy_data(AggDemandEconomy)
+InfHorizonTypeAgg_h.get_economy_data(AggDemandEconomy)
+InfHorizonTypeAgg_c.get_economy_data(AggDemandEconomy)
 BaseTypeList = [InfHorizonTypeAgg_d, InfHorizonTypeAgg_h, InfHorizonTypeAgg_c ]
   
 # Fill in the Markov income distribution for each base type
@@ -29,7 +29,7 @@ IncomeDstn_unemp_nobenefits = DiscreteDistribution(np.array([1.0]), [np.array([1
 for ThisType in BaseTypeList:
     EmployedIncomeDstn = deepcopy(ThisType.IncomeDstn[0])
     ThisType.IncomeDstn[0] = [ThisType.IncomeDstn[0]] + [IncomeDstn_unemp]*UBspell_normal + [IncomeDstn_unemp_nobenefits] 
-    ThisType.IncomeDstn_base = ThisType.IncomeDstn
+    ThisType.IncShkDstn_base = ThisType.IncomeDstn
     
 # Make the overall list of types
 TypeList = []
@@ -38,7 +38,7 @@ myAggTotal = 0
 for e in range(num_types):
     for b in range(DiscFacDstns[0].atoms[0].size):
         DiscFac = DiscFacDstns[e].atoms[0][b]
-        AgentCount = int(np.floor(AgentCountTotal*EducShares[e]*DiscFacDstns[e].pmf[b]))
+        AgentCount = int(np.floor(AgentCountTotal*EducShares[e]*DiscFacDstns[e].pmv[b]))
         ThisType = deepcopy(BaseTypeList[e])
         ThisType.AgentCount = AgentCount
         ThisType.DiscFac = DiscFac
@@ -54,13 +54,13 @@ AggDemandEconomy.solve()
 
 AggDemandEconomy.reset()
 for agent in AggDemandEconomy.agents:
-    agent.initializeSim()
+    agent.initialize_sim()
     agent.AggDemandFac = 1.0
     agent.RfreeNow = 1.0
     agent.CaggNow = 1.0
 
-AggDemandEconomy.makeHistory()   
-AggDemandEconomy.saveState()   
+AggDemandEconomy.make_history()   
+AggDemandEconomy.save_state()   
 AggDemandEconomy.switchToCounterfactualMode("base")
 AggDemandEconomy.makeIdiosyncraticShockHistories()
 

--- a/Code/HA-Models/FromPandemicCode/FiscalTools.py
+++ b/Code/HA-Models/FromPandemicCode/FiscalTools.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 from copy import deepcopy
-from HARK import multiThreadCommands, multiThreadCommandsFake
+from HARK import multi_thread_commands, multi_thread_commands_fake
 
 mystr = lambda x : '{:.2f}'.format(x)
 mystr2 = lambda x : '{:.3f}'.format(x)
@@ -47,9 +47,9 @@ def runExperiment(agents,RecessionShock = False,TaxCutShock = False, \
     # Update the perceived and actual Markov arrays, solve and re-draw shocks if
     # warranted, then impose the recession shock, and finally
     # simulate the model for three years.
-    experiment_commands = ['updateMrkvArray()', 'solveIfChanged()',
-                           'makeShocksIfChanged()', 'initializeSim()',
-                           'hitWithRecessionShock()',
+    experiment_commands = ['update_mrkv_array()', 'solve_if_changed()',
+                           'make_shocks_if_changed()', 'initialize_sim()',
+                           'hit_with_recession_shock()',
                            'simulate()']
     multiThreadCommandsFake(agents, experiment_commands)
     

--- a/Code/HA-Models/FromPandemicCode/HA-Fiscal-HANK-SAM.py
+++ b/Code/HA-Models/FromPandemicCode/HA-Fiscal-HANK-SAM.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import numpy as np
-from HARK.distribution import DiscreteDistribution
+from HARK.distributions import DiscreteDistribution
 from ConsMarkovModel import MarkovConsumerType
 from copy import deepcopy
 from Parameters import returnParameters

--- a/Code/HA-Models/FromPandemicCode/Parameters.py
+++ b/Code/HA-Models/FromPandemicCode/Parameters.py
@@ -14,7 +14,7 @@ def returnParameters(Parametrization='Baseline',OutputFor='_Main.py'):
         Abs_Path = cwd + '/FromPandemicCode'
 
     import numpy as np
-    from HARK.distribution import Uniform
+    from HARK.distributions import Uniform
     from OtherFunctions import loadPickle, getSimulationDiff
     
 
@@ -451,10 +451,10 @@ def returnParameters(Parametrization='Baseline',OutputFor='_Main.py'):
                     "aXtraNestFac": aXtraNestFac,
                     "CubicBool": False,
                     "vFuncBool": False,
-                    'aNrmInitMean': np.log(0.00001), # Initial assets are zero
-                    'aNrmInitStd': 0.0,
-                    'pLvlInitMean': pLvlInitMean_d,
-                    'pLvlInitStd': pLvlInitStd_d,
+                    'kLogInitMean': np.log(0.00001), # Initial assets are zero
+                    'kLogInitStd': 0.0,
+                    'pLogInitMean': pLvlInitMean_d,
+                    'pLogInitStd': pLvlInitStd_d,
                     "MrkvPrbsInit" : np.array(list(init_mrkv_dist_d)),
                     'Urate_normal' : Urate_normal_d,
                     'Uspell_normal' : Uspell_normal,
@@ -496,8 +496,8 @@ def returnParameters(Parametrization='Baseline',OutputFor='_Main.py'):
         "CondMrkvArrays_recessionTaxCut" : CondMrkvArrays_recessionTaxCut_h,
         "MrkvArray_recessionCheck" : MrkvArray_recessionCheck_h,
         "CondMrkvArrays_recessionCheck" : CondMrkvArrays_recessionCheck_h,  
-        'pLvlInitMean': pLvlInitMean_h,
-        'pLvlInitStd': pLvlInitStd_h,
+        'pLogInitMean': pLvlInitMean_h,
+        'pLogInitStd': pLvlInitStd_h,
         "MrkvPrbsInit" : np.array(list(init_mrkv_dist_h)),
         'Urate_normal' : Urate_normal_h,
         'Urate_recession' : Urate_recession_h,
@@ -520,8 +520,8 @@ def returnParameters(Parametrization='Baseline',OutputFor='_Main.py'):
         "CondMrkvArrays_recessionTaxCut" : CondMrkvArrays_recessionTaxCut_c,
         "MrkvArray_recessionCheck" : MrkvArray_recessionCheck_c,
         "CondMrkvArrays_recessionCheck" : CondMrkvArrays_recessionCheck_c, 
-        'pLvlInitMean': pLvlInitMean_c,
-        'pLvlInitStd': pLvlInitStd_c,
+        'pLogInitMean': pLvlInitMean_c,
+        'pLogInitStd': pLvlInitStd_c,
         "MrkvPrbsInit" : np.array(list(init_mrkv_dist_c)),
         'Urate_normal' : Urate_normal_c,
         'Urate_recession' : Urate_recession_c,

--- a/Code/HA-Models/FromPandemicCode/Simulate.py
+++ b/Code/HA-Models/FromPandemicCode/Simulate.py
@@ -2,7 +2,7 @@ def Simulate(Run_Dict,figs_dir,Parametrization='Baseline'):
     
     
     from AggFiscalModel import AggFiscalType, AggregateDemandEconomy
-    from HARK.distribution import DiscreteDistribution
+    from HARK.distributions import DiscreteDistribution
     from time import time
     import numpy as np
     from copy import deepcopy

--- a/Code/HA-Models/Target_AggMPCX_LiquWealth/Estimation_BetaNablaSplurge.py
+++ b/Code/HA-Models/Target_AggMPCX_LiquWealth/Estimation_BetaNablaSplurge.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import pandas as pd
 
 # Import needed tools from HARK
-from HARK.distribution import Uniform
+from HARK.distributions import Uniform
 from HARK.utilities import get_percentiles, get_lorenz_shares, make_figs
 from HARK.parallel import multi_thread_commands
 from scipy.optimize import minimize
@@ -48,7 +48,7 @@ base_params['PermShkStd']   = [0.001**0.5]  #from stickyE paper
 base_params['TranShkStd']   = [0.132**0.5]  #from stickyE paper
 base_params['T_age']        = 400           # Kill off agents if they manage to achieve T_kill working years
 base_params['AgentCount']   = 5000          # Number of agents per instance of IndShockConsType
-base_params['pLvlInitMean'] = np.log(23.72) 
+base_params['pLogInitMean'] = np.log(23.72) 
 base_params['T_sim']        = 800
 
 
@@ -58,7 +58,7 @@ if  Parametrization == 'NOR':
     base_params['Rfree']        = 1.02**0.25
     base_params['Rsave']        = 1.02**0.25
     base_params['Rboro']        = 1.137**0.25
-    base_params['pLvlInitMean'] = 0 
+    base_params['pLogInitMean'] = 0 
     base_params['UnempPrb']     = 0.044
     base_params['IncUnemp']     = 0.60
     base_params['PermShkStd']   = [0.001**0.5] #from Crawley,Moll,Tretvoll
@@ -251,7 +251,7 @@ def FagerengObjFunc(SplurgeEstimate,center,spread,verbose=False,estimation_mode=
                     P_hist[:,period] = ThisType.shocks["PermShk"]
                     for i_agent in range(ThisType.AgentCount):
                         if ThisType.shocks["TranShk"][i_agent] == 1.0: # indicator of death
-                            a_actu[i_agent,period-1,k] = np.exp(base_params['aNrmInitMean'])
+                            a_actu[i_agent,period-1,k] = np.exp(base_params['kLogInitMean'])
                     m_adj = a_actu[:,period-1,k]*R_kink/ThisType.shocks["PermShk"] + ThisType.shocks["TranShk"] + Lnrm - SplurgeNrm #continue with resources from last period
                     c_actu[:,period,k] = ThisType.cFunc[0](m_adj) + SplurgeNrm
                     c_actu_Lvl[:,period,k] = c_actu[:,period,k] * ThisType.state_now["pLvl"]

--- a/Code/HA-Models/Target_AggMPCX_LiquWealth/SetupParamsCSTW.py
+++ b/Code/HA-Models/Target_AggMPCX_LiquWealth/SetupParamsCSTW.py
@@ -49,9 +49,9 @@ T_age = T_cycle + 1           # Don't let simulated agents survive beyond this a
 pLvlInitMean_d = np.log(5)    # average initial permanent income, dropouts
 pLvlInitMean_h = np.log(7.5)  # average initial permanent income, HS grads
 pLvlInitMean_c = np.log(12)   # average initial permanent income, college grads
-pLvlInitStd = 0.4             # Standard deviation of initial permanent income
-aNrmInitMean = np.log(0.5)    # log initial wealth/income mean
-aNrmInitStd  = 0.5            # log initial wealth/income standard deviation
+pLogInitStd = 0.4             # Standard deviation of initial permanent income
+kLogInitMean = np.log(0.5)    # log initial wealth/income mean
+kLogInitStd  = 0.5            # log initial wealth/income standard deviation
 
 # Set population macro parameters
 PopGroFac = 1.01**(0.25)      # Population growth rate
@@ -120,10 +120,10 @@ init_infinite = {"CRRA":CRRA,
                 'T_sim':T_sim_PY,
                 'T_age': 400,
                 'IndL': IndL,
-                'aNrmInitMean':np.log(0.00001),
-                'aNrmInitStd':0.0,
-                'pLvlInitMean':0.0,
-                'pLvlInitStd':0.0,
+                'kLogInitMean':np.log(0.00001),
+                'kLogInitStd':0.0,
+                'pLogInitMean':0.0,
+                'pLogInitStd':0.0,
                 'AgentCount':0, # will be overwritten by parameter distributor
                 }
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -6,5 +6,5 @@ runipy==0.1.5
 pytest==6.2.4
 jupyter==1.0.0
 jupyter_contrib_nbextensions==0.5.1
-econ-ark==0.14.1
+econ-ark==0.17.0
 

--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,8 @@ channels:
   - defaults
 
 dependencies:
-  # Python version - REQUIRED: 3.9.x due to econ-ark dependencies
-  - python=3.9
+  # Python version - REQUIRED: 3.10+ due to econ-ark dependencies due to econ-ark dependencies
+  - python=3.10
 
   # Core scientific computing stack (from conda for optimized builds)
   - numpy>=1.24,<2
@@ -54,6 +54,6 @@ dependencies:
   - pip
   - pip:
       # econ-ark and dependencies only on PyPI
-      - econ-ark==0.14.1
+      - econ-ark==0.17.0
       # Jupyter notebook converter (not on conda)
       - ipynb-py-convert>=0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "hafiscal"
 version = "1.0.0"
 description = "HAFiscal: Household Fiscal Policy Model"
-requires-python = ">=3.9,<3.10"
+requires-python = ">=3.10,<3.12"
 authors = [
     {name = "Christopher D. Carroll", email = "ccarroll@llorracc.org"},
 ]
@@ -16,13 +16,13 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Economics",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: Apache Software License",
 ]
 
 dependencies = [
     # Economics packages
-    "econ-ark==0.14.1",
+    "econ-ark==0.17.0",
     "sequence-jacobian==1.0.0",
     
     # Core scientific computing stack
@@ -130,7 +130,7 @@ exclude = ["*"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 extend-exclude = [
     ".venv",
     "venv",
@@ -151,7 +151,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true


### PR DESCRIPTION
Major changes:
- Updated config files: econ-ark==0.14.1 → econ-ark==0.17.0
  * pyproject.toml
  * environment.yml
  * binder/requirements.txt
- Updated Python version requirement: 3.9 → 3.10+
- Import changes: HARK.distribution → HARK.distributions (10 files)
- Attribute renames: .pmf → .pmv, .IncomeDstn → .IncShkDstn
- Method renames: initializeSim → initialize_sim
- Fixed DiscreteDistribution constructor: scalar → array

This upgrade spans multiple versions (0.14.1 → 0.16.1 → 0.17.0) and includes all breaking changes from the meta-prompt discovery process.